### PR TITLE
add import os

### DIFF
--- a/genderComputer.py
+++ b/genderComputer.py
@@ -17,6 +17,7 @@ GNU Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>."""
 
+import os
 import re
 from dictUtils import MyDict
 from unicodeMagic import UnicodeReader


### PR DESCRIPTION
## In [8]: gc = GenderComputer(os.path.abspath("./nameLists/"))

NameError                                 Traceback (most recent call last)
<ipython-input-8-caa34df6e604> in <module>()
----> 1 gc = GenderComputer(os.path.abspath("./nameLists/"))

/home/h4nt1/repos/genderComputer/genderComputer.pyc in **init**(self, nameListsPath)
     91 class GenderComputer():
     92         def **init**(self, nameListsPath):
---> 93                 '''Data path'''
     94                 self.dataPath = os.path.abspath(nameListsPath)
     95 

NameError: global name 'os' is not defined
