### PR TITLE
Allow newer versions of deps to avoid conflicts with other libs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,6 @@ setuptools.setup(
         'genderComputer': ['nameLists/*.*'],
     },
     include_package_data=True,
-    install_requires = ['unidecode==1.3.2','nameparser==1.0.6'],
+    install_requires = ['unidecode>=1.3.2','nameparser>=1.0.6'],
     zip_safe=False
 )


### PR DESCRIPTION
== is too restrictive and may cause unresolvable conflicts in some cases. Changing to >=